### PR TITLE
Start ollama service with port conflict

### DIFF
--- a/private-agent/frontend/Dockerfile
+++ b/private-agent/frontend/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies
-RUN npm ci
+RUN npm install
 
 # Copy source code
 COPY . .


### PR DESCRIPTION
Fix frontend Dockerfile to use `npm install` instead of `npm ci`.

The `npm ci` command failed during the Docker build because a `package-lock.json` file was not present. Changing to `npm install` allows the dependencies to be installed and a lock file to be generated if one doesn't exist.

---
<a href="https://cursor.com/background-agent?bcId=bc-26347573-ff5a-4adb-9af8-a6425dc6168a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-26347573-ff5a-4adb-9af8-a6425dc6168a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

