### PR TITLE
Fix frontend build error

### DIFF
--- a/private-agent/frontend/src/vite-env.d.ts
+++ b/private-agent/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
Add `vite-env.d.ts` to resolve TypeScript error `Property 'env' does not exist on type 'ImportMeta'` during frontend build.

The `vite-env.d.ts` file provides the necessary type definitions for Vite's `import.meta.env` to the TypeScript compiler, which was previously causing a build failure.

---
<a href="https://cursor.com/background-agent?bcId=bc-72f2891d-1441-4c3a-bc4c-128faafa641f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-72f2891d-1441-4c3a-bc4c-128faafa641f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

