### PR TITLE
Fix frontend build error

### DIFF
--- a/private-agent/frontend/src/vite-env.d.ts
+++ b/private-agent/frontend/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="vite/client" />
+


### PR DESCRIPTION
Add `vite-env.d.ts` to resolve the `Property 'env' does not exist on type 'ImportMeta'` TypeScript error during frontend build.

---
<a href="https://cursor.com/background-agent?bcId=bc-e9170395-aafd-47d9-a72f-b19627c6d09b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e9170395-aafd-47d9-a72f-b19627c6d09b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

