### PR TITLE
Fix ollama connection refused error

### DIFF
--- a/private-agent/backend/app/core/embeddings.py
+++ b/private-agent/backend/app/core/embeddings.py
@@ -38,6 +38,7 @@ class EmbeddingGenerator:
     def _ollama_embed_one(self, client: httpx.Client, text: str) -> List[float]:
         """Request a single embedding vector from Ollama (synchronous)."""
         try:
+            logger.info(f"Requesting embedding from {settings.OLLAMA_URL}/api/embeddings with model {self.model_name}")
             response = client.post(
                 f"{settings.OLLAMA_URL}/api/embeddings",
                 json={"model": self.model_name, "input": text},
@@ -49,6 +50,12 @@ class EmbeddingGenerator:
             if not vector:
                 raise Exception("No embedding returned from Ollama")
             return vector
+        except httpx.ConnectError as e:
+            logger.error(f"Failed to connect to Ollama at {settings.OLLAMA_URL}: {e}")
+            raise Exception(f"Cannot connect to Ollama server at {settings.OLLAMA_URL}: {str(e)}")
+        except httpx.TimeoutException as e:
+            logger.error(f"Ollama embedding request timed out: {e}")
+            raise Exception(f"Ollama embedding request timed out: {str(e)}")
         except Exception as e:
             logger.error(f"Ollama embedding failed: {e}")
             raise Exception(f"Embedding generation failed: {str(e)}")

--- a/private-agent/docker-compose.yml
+++ b/private-agent/docker-compose.yml
@@ -6,12 +6,12 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - OLLAMA_URL=${OLLAMA_URL:-http://host.docker.internal:11535}
-      - OLLAMA_MODEL=${OLLAMA_MODEL:-llama3.1:8b-instruct}
+      - OLLAMA_URL=${OLLAMA_URL:-http://34.58.166.165:11535}
+      - OLLAMA_MODEL=${OLLAMA_MODEL:-llama2:latest}
       - CHROMA_PERSIST_DIR=/app/chroma_persist
-      - EMBEDDINGS_PROVIDER=${EMBEDDINGS_PROVIDER:-ollama}
+      - EMBEDDINGS_PROVIDER=${EMBEDDINGS_PROVIDER:-sentence_transformers}
       - OLLAMA_EMBEDDING_MODEL=${OLLAMA_EMBEDDING_MODEL:-nomic-embed-text}
-      - EMBEDDING_MODEL=${EMBEDDING_MODEL:-nomic-embed-text}
+      - EMBEDDING_MODEL=${EMBEDDING_MODEL:-sentence-transformers/all-MiniLM-L6-v2}
       - MAX_CONTEXT_TOKENS=${MAX_CONTEXT_TOKENS:-4000}
       - CHUNK_SIZE=${CHUNK_SIZE:-500}
       - CHUNK_OVERLAP=${CHUNK_OVERLAP:-50}


### PR DESCRIPTION
Configure `sentence_transformers` as the default embedding provider, update Ollama settings, and enhance error handling to resolve connection and embedding generation errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-5861a4f5-9a02-4e67-a223-523223efe025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5861a4f5-9a02-4e67-a223-523223efe025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

