### PR TITLE
Fix docker compose version and bad requests

### DIFF
--- a/private-agent/backend/app/main.py
+++ b/private-agent/backend/app/main.py
@@ -41,22 +41,22 @@ app.include_router(memory.router, prefix="/api", tags=["memory"])
 @app.options("/api/chat")
 async def options_chat():
     """Handle CORS preflight requests for chat endpoint."""
-    return {"message": "ok"}
+    return JSONResponse(content={"message": "ok"})
 
 @app.options("/api/upload")
 async def options_upload():
     """Handle CORS preflight requests for upload endpoint."""
-    return {"message": "ok"}
+    return JSONResponse(content={"message": "ok"})
 
 @app.options("/api/agents")
 async def options_agents():
     """Handle CORS preflight requests for agents endpoint."""
-    return {"message": "ok"}
+    return JSONResponse(content={"message": "ok"})
 
 @app.options("/api/memory")
 async def options_memory():
     """Handle CORS preflight requests for memory endpoint."""
-    return {"message": "ok"}
+    return JSONResponse(content={"message": "ok"})
 
 @app.get("/")
 async def root():

--- a/private-agent/docker-compose.yml
+++ b/private-agent/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   backend:
     build: ./backend


### PR DESCRIPTION
Remove obsolete `version` attribute from `docker-compose.yml` and fix FastAPI OPTIONS handlers to return `JSONResponse` to resolve warnings and 400 Bad Request errors.

The original OPTIONS handlers in `main.py` were returning plain Python dictionaries, which FastAPI does not automatically convert into a proper HTTP response for preflight requests, leading to 400 Bad Request errors. Explicitly returning `JSONResponse` ensures correct handling of these requests.

---
<a href="https://cursor.com/background-agent?bcId=bc-3a20ad4f-0fba-4e55-ac1c-8b4f599da8fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3a20ad4f-0fba-4e55-ac1c-8b4f599da8fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

